### PR TITLE
Update opt.zoom.ZoomLauncher

### DIFF
--- a/opt.zoom.ZoomLauncher
+++ b/opt.zoom.ZoomLauncher
@@ -1,193 +1,182 @@
+# Last Modified: Mon Oct 26 19:09:44 2020
 #include <tunables/global>
 
 /opt/zoom/ZoomLauncher {
+  #include <abstractions/X>
   #include <abstractions/audio>
   #include <abstractions/base>
-  #include <abstractions/dbus-strict>
+  #include <abstractions/dbus-accessibility-strict>
   #include <abstractions/dbus-session-strict>
-  #include <abstractions/freedesktop.org>
+  #include <abstractions/dbus-strict>
   #include <abstractions/fonts>
+  #include <abstractions/freedesktop.org>
   #include <abstractions/nameservice>
   #include <abstractions/openssl>
   #include <abstractions/private-files-strict>
   #include <abstractions/user-tmp>
   #include <abstractions/video>
-  #include <abstractions/X>
   #include <abstractions/wayland>
 
-  #include <abstractions/dbus-accessibility-strict>
+  dbus (receive send) bus=accessibility,
+  dbus receive bus=session interface=org.a11y.atspi**,
+  dbus receive bus=system path=/org/freedesktop/NetworkManager,
+  dbus send bus=session peer=(name=org.a11y.Bus),
+  dbus send bus=system path=/org/freedesktop/NetworkManager member=state,
   dbus (send)
        bus=session
-       peer=(name=org.a11y.Bus),
-  dbus (receive)
-       bus=session
-       interface=org.a11y.atspi**,
-  dbus (receive, send)
-       bus=accessibility,
+       path=/org/gnome/GConf/Server
+       interface=org.gnome.GConf.Server
+       member=GetDefaultDatabase
+       peer=(label=unconfined),
 
-  # for networking
-  network inet stream,
-  network inet6 stream,
-  @{PROC}/[0-9]*/net/if_inet6 r,
-  @{PROC}/[0-9]*/net/ipv6_route r,
-  @{PROC}/[0-9]*/net/dev r,
-  @{PROC}/[0-9]*/net/wireless r,
   dbus (send)
-       bus=system
-       path=/org/freedesktop/NetworkManager
-       member=state,
-  dbus (receive)
-       bus=system
-       path=/org/freedesktop/NetworkManager,
+       bus=session
+       path=/org/gnome/GConf/Database/*
+       member=LookupExtended
+       peer=(label=unconfined),
+       
+  signal send set=usr2 peer=/usr/bin/pacmd,
 
-  # pulse audo configuration
-  signal (send) peer=/usr/bin/pacmd set=(usr2),
-  /usr/bin/pactl ix,
-  /usr/bin/pacmd ix,
+  deny ptrace trace,
 
-  /bin/dash ix,
-  /bin/cat ix,
-  /bin/grep ix,
-  /bin/readlink ix,
-  /sbin/killall5 ix,
-  /usr/bin/lscpu ix,
-  /usr/bin/lspci ix,
-  /opt/zoom/zopen ix,
-  /usr/bin/xdg-open Uxr,
+  ptrace read peer=/opt/zoom/QtWebEngineProcess,
 
-  /usr/share/fonts/truetype/** rm,
-  /usr/share/fontconfig/conf.avail/ r,
-  /usr/share/fontconfig/conf.avail/** r,
+  deny @{HOME}/.Private mrwlk,
+  deny @{PROC}/[0-9]*/cmdline mrwlk,
+
+  /usr/bin/cat ix,
+  /usr/bin/dash ix,
+  /usr/bin/grep ix,
+  /usr/bin/ps rUx,
+  /usr/bin/readlink ix,
+  /usr/bin/uname rUx,
+  /usr/bin/gconftool-2 ix,
+  /dev/dri/ r,
+  /dev/tty rw,
+  /dev/video[0-9] mrw,
+  /etc/debian-version r,
+  /etc/os-release r,
+  /etc/passwd m,
+  /etc/timezone r,
   /opt/ r,
-  /opt/zoom/ rm,
-  /opt/zoom/** rm,
-  /opt/zoom/RegisterProtocol/ rw,
-  /opt/zoom/QtQuick/ r,
-  /opt/zoom/QtQuick/** rm,
-  /opt/zoom/QtQuick.2/** rm,
-  /opt/zoom/iconengines/lib* rm,
-  /opt/zoom/imageformats/lib* rm,
-  /opt/zoom/platforms/lib* rm,
-  /opt/zoom/platforminputcontexts/lib* rm,
-  /opt/zoom/platformthemes/lib*.so* rm,
-  /opt/zoom/lib*.so.* rm,
-  /opt/zoom/xcbglintegrations/*.so rm,
-  ptrace (read) peer=/opt/zoom/QtWebEngineProcess,
-
+  /opt/zoom/ mr,
+  /opt/zoom/** mr,
+  /opt/zoom/QtQuick.2/** mr,
+  /opt/zoom/QtQuick/** mr,
   /opt/zoom/QtWebEngineProcess ix,
+  /opt/zoom/RegisterProtocol/ rw,
+  /opt/zoom/iconengines/lib* mr,
+  /opt/zoom/imageformats/lib* mr,
+  /opt/zoom/lib*.so.* mr,
+  /opt/zoom/platforminputcontexts/lib* mr,
+  /opt/zoom/platforms/lib* mr,
+  /opt/zoom/platformthemes/lib*.so* mr,
   /opt/zoom/qtdiag ix,
+  /opt/zoom/xcbglintegrations/*.so mr,
   /opt/zoom/zoom ix,
-
-  @{PROC} r,
-  owner @{PROC}/@{pid}/fd/ r,
-  owner @{PROC}/@{pid}/mounts r,
-  @{PROC}/@{pid}/stat r,
-  @{PROC}/@{pid}/task/* r,
-  @{PROC}/@{pid}/oom_score_adj w,
-  @{PROC}/bus/pci/devices r,
-  @{PROC}/sys/kernel/pid_max r,
-  @{PROC}/sys/kernel/osrelease r,
-  deny @{PROC}/[0-9]*/cmdline mrwkl,
-  deny ptrace (trace),
-
-  /sys/devices/pci[0-9]*/**/{busnum,class,config,device,devnum,descriptors,irq,resource,revision,speed,subsystem_device,subsystem_vendor,uevent,vendor} r,
+  /opt/zoom/zopen ix,
+  /usr/sbin/killall5 ix,
+  /usr/bin/pidof ix,
   /sys/bus/pci/devices/ r,
-  /usr/share/misc/pci.ids r,
-  /usr/share/icons/hicolor/** rm,
-
+  /sys/devices/pci[0-9]*/**/{busnum,class,config,device,devnum,descriptors,irq,resource,revision,speed,subsystem_device,subsystem_vendor,uevent,vendor} r,
+  /sys/devices/system/cpu/cpu*/cache/index*/{type,level,shared_cpu_map,size} r,
+  /sys/devices/system/cpu/cpu*/topology/{core_id,physical_package_id,core_siblings,thread_siblings} r,
   /sys/devices/system/cpu/cpufreq/policy*/{cpuinfo_max_freq,cpuinfo_min_freq} r,
   /sys/devices/system/cpu/kernel_max r,
   /sys/devices/system/cpu/{possible,present} r,
-  /sys/devices/system/cpu/cpu*/topology/{core_id,physical_package_id,core_siblings,thread_siblings} r,
-  /sys/devices/system/cpu/cpu*/cache/index*/{type,level,shared_cpu_map,size} r,
   /sys/devices/system/node/ r,
   /sys/devices/system/node/node0/cpumap r,
-
-  /dev/tty rw,
-  /dev/dri/ r,
-  /dev/video[0-9] rwm,
-
-  deny @{HOME}/.Private mrwkl,
-  owner @{HOME}/.zoom/ rwk,
-  owner @{HOME}/.zoom/** rwk,
-  owner @{HOME}/.zoom/data/ rwk,
-  owner @{HOME}/.zoom/data/** rwmk,
-  owner @{HOME}/.cache/qt_compose_cache_little_endian* rw,
-  owner @{HOME}/.cache/qtshadercache/ rw,
-  owner @{HOME}/.cache/qtshadercache/** rmw,
+  /usr/bin/gsettings Ux,
+  /usr/bin/lsb_release rCx -> lsb_release,
+  /usr/bin/lscpu ix,
+  /usr/bin/lspci ix,
+  /usr/bin/mkfifo rUx, # investigate
+  /usr/bin/pacmd ix,
+  /usr/bin/pactl ix,
+  /usr/bin/xdg-open rUx,
+  /usr/share/fontconfig/conf.avail/** r,
+  /usr/share/fonts/truetype/** mr,
+  /usr/share/glib-2.0/schemas/gschemas.compiled r,
+  /usr/share/icons/hicolor/** mr,
+  /usr/share/mime/mime.cache m,
+  /usr/share/misc/pci.ids r,
+  /usr/share/themes/Default/gtk-3.0/gtk-keys.css r,
+  /var/lib/flatpak/exports/share/mime/mime.cache m,
+  @{PROC} r,
+  @{PROC}/@{pid}/oom_score_adj w,
+  @{PROC}/@{pid}/stat r,
+  @{PROC}/@{pid}/task/* r,
+  @{PROC}/[0-9]*/net/dev r,
+  @{PROC}/[0-9]*/net/if_inet6 r,
+  @{PROC}/[0-9]*/net/ipv6_route r,
+  @{PROC}/[0-9]*/net/wireless r,
+  @{PROC}/bus/pci/devices r,
+  @{PROC}/sys/kernel/osrelease r,
+  @{PROC}/sys/kernel/pid_max r,
+  owner "@{HOME}/.config/Unknown Organization/" rw,
+  owner "@{HOME}/.config/Unknown Organization/**" rwk,
+  owner /dev/shm/.org.chromium.Chromium* mrw,
+  owner /{,var/}run/user/*/dconf/user rw,
+  owner @{HOME}/.config/QtProject.conf r,
   owner @{HOME}/.cache/mesa_shader_cache/ rw,
   owner @{HOME}/.cache/mesa_shader_cache/** rwk,
-  owner @{HOME}/.cache/mesa_shader_cache/index rwm,
+  owner @{HOME}/.cache/mesa_shader_cache/index mrw,
+  owner @{HOME}/.cache/qt_compose_cache_little_endian* rw,
+  owner @{HOME}/.cache/qtshadercache/ rw,
+  owner @{HOME}/.cache/qtshadercache/** mrw,
   owner @{HOME}/.cache/zoom/ rwk,
   owner @{HOME}/.cache/zoom/** rwk,
-  owner @{HOME}/.cache/zoom/qmlcache/ rwmk,
-  owner @{HOME}/.cache/zoom/qmlcache/** rwmk,
-  owner @{HOME}/.config/zoomus.conf* rwk,
+  owner @{HOME}/.cache/zoom/QtWebEngine/Default/Cache/* mr,
+  owner @{HOME}/.cache/zoom/qmlcache/ mrwk,
+  owner @{HOME}/.cache/zoom/qmlcache/** mrwk,
   owner @{HOME}/.config/.@{pid} rwk,
+  owner @{HOME}/.config/.J* rwk,
+  owner @{HOME}/.config/.T* rwk,
+  owner @{HOME}/.config/dconf/user rw,
+  owner @{HOME}/.config/gtk-3.0/settings.ini r,
   owner @{HOME}/.config/ibus/bus/* r,
+  owner @{HOME}/.config/zoomus.conf* rwk,
+  owner @{HOME}/.glvnd* mrw,
   owner @{HOME}/.local/share/mime/mime.cache m,
   owner @{HOME}/.local/share/zoom/ rwk,
   owner @{HOME}/.local/share/zoom/** rwk,
-  owner @{HOME}/.cache/zoom/QtWebEngine/Default/Cache/* rm,
-  owner @{HOME}/.config/.J* rwk,
-  owner @{HOME}/.config/gtk-3.0/settings.ini r,
-  owner "@{HOME}/.config/Unknown Organization/" rw,
-  owner "@{HOME}/.config/Unknown Organization/**" rwk,
-  owner @{HOME}/.glvnd* rwm,
-  owner @{HOME}/.config/.T* rwk,
-  owner @{HOME}/.config/dconf/user rw,
-  owner /{,var/}run/user/*/dconf/user rw,
   owner @{HOME}/.pki/nssdb/cert9.db r,
   owner @{HOME}/.pki/nssdb/pkcs11.txt r,
-  owner /dev/shm/.org.chromium.Chromium* rwm,
+  owner @{HOME}/.zoom/ rwk,
+  owner @{HOME}/.zoom/** rwk,
+  owner @{HOME}/.zoom/data/ rwk,
+  owner @{HOME}/.zoom/data/** mrwk,
+  owner @{PROC}/@{pid}/fd/ r,
+  owner @{PROC}/@{pid}/mounts r,
+  @{HOME}/Pictures/ r,
+  /tmp/ r,
 
-  /var/lib/flatpak/exports/share/mime/mime.cache m,
-  /usr/share/mime/mime.cache m,
-
-  /usr/bin/gsettings Ux,
-  /usr/share/glib-2.0/schemas/gschemas.compiled r,
-  /usr/share/themes/Default/gtk-3.0/gtk-keys.css r,
-
-  /etc/passwd m,
-
-  /etc/os-release r,
-  /etc/debian-version r,
-  # Miscellaneous (to be abstracted)
-  # Ideally these would use a child profile. They are all ELF executables
-  # so running with 'Ux', while not ideal, is ok because we will at least
-  # benefit from glibc's secure execute.
-  /usr/bin/mkfifo Uxr,  # investigate
-  /bin/ps Uxr,
-  /bin/uname Uxr,
-  /usr/bin/lsb_release Cxr -> lsb_release,
   profile lsb_release {
     #include <abstractions/base>
     #include <abstractions/python>
-    /usr/bin/lsb_release r,
-    /usr/share/distro-info/debian.csv r,
-    /etc/dpkg/origins/* r,
-    /etc/debian_version r,
-    /usr/local/lib/python3.[0-4]/dist-packages/ r,
-    /usr/bin/ r,
-    /usr/bin/python3.[0-8] ixr,
 
-    /usr/bin/apt-cache ix,
+    deny /tmp/gtalkplugin.log w,
+
     /etc/apt/** r,
+    /etc/debian_version r,
+    /etc/dpkg/** r,
+    /etc/dpkg/origins/* r,
+    /usr/bin/ r,
+    /usr/bin/apt-cache ix,
+    /usr/bin/dpkg ix,
+    /usr/bin/lsb_release r,
+    /usr/bin/python3.[0-8] rix,
+    /usr/local/lib/python3.[0-4]/dist-packages/ r,
+    /usr/share/distro-info/debian.csv r,
+    /usr/share/dpkg/ r,
+    /usr/share/dpkg/** r,
     /var/cache/apt/** r,
     /var/lib/apt/lists/ r,
     /var/lib/apt/lists/** r,
-    /usr/share/dpkg/ r,
-    /usr/share/dpkg/** r,
+    /var/lib/dpkg/** r,
+    owner /tmp/** mrw,
     owner @{PROC}/[0-9]*/fd/ r,
     owner @{PROC}/[0-9]*/fd/** r,
 
-    /usr/bin/dpkg ix,
-    /var/lib/dpkg/** r,
-    /etc/dpkg/** r,
-
-    owner /tmp/** rwm,
-
-    # file_inherit
-    deny /tmp/gtalkplugin.log w,
   }
 }


### PR DESCRIPTION
Some /sbin => /usr/bin/ substitution (ubuntu)
Allowed some dbus calls

Note: apparmor rewrote my changes (automatically order lines, etc...), I didn't kept note of them... sorry for the diff.

The only last complains is that every 10 minutes, Zoom pools for process running on the machine (opening all `/proc/*/cmdline`)
(`AVC apparmor="DENIED" operation="ptrace" profile="/opt/zoom/ZoomLauncher" pid=31790 comm="pidof" requested_mask="read" denied_mask="read" peer="unconfined"`) which I don't know how to properly silence (and deny).